### PR TITLE
Add regex-based path matching; complete functionality for SSR

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theracode/router",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Router for Stencil apps that focuses on smooth transitions and eliminating visual tearing",
   "module": "dist/collection/index.js",
   "main": "dist/index.js",

--- a/packages/router/src/components.d.ts
+++ b/packages/router/src/components.d.ts
@@ -13,9 +13,12 @@ declare global {
   }
   namespace JSXElements {}
 
+  interface HTMLElement {
+    componentOnReady?: () => Promise<this | null>;
+  }
+
   interface HTMLStencilElement extends HTMLElement {
     componentOnReady(): Promise<this>;
-    componentOnReady(done: (ele?: this) => void): void;
 
     forceUpdate(): void;
   }
@@ -27,6 +30,7 @@ import {
   EventEmitter,
 } from '@stencil/core';
 import {
+  MatchResults,
   RouteLinkClickEventDetail,
 } from './components/interfaces';
 
@@ -69,8 +73,9 @@ declare global {
   namespace StencilComponents {
     interface ThRoute {
       'component': string;
+      'exact': boolean;
       'isActive': () => boolean;
-      'isMatch': (url: string) => boolean;
+      'isMatch': (pathname: string) => MatchResults;
       'setActive': (active: boolean) => void;
       'url': string;
     }
@@ -96,6 +101,7 @@ declare global {
   namespace JSXElements {
     export interface ThRouteAttributes extends HTMLAttributes {
       'component'?: string;
+      'exact'?: boolean;
       'url'?: string;
     }
   }

--- a/packages/router/src/components/index.ts
+++ b/packages/router/src/components/index.ts
@@ -1,2 +1,0 @@
-export * from './interfaces';
-export * from './router-state';

--- a/packages/router/src/components/index.ts
+++ b/packages/router/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './router-state';

--- a/packages/router/src/components/interfaces.ts
+++ b/packages/router/src/components/interfaces.ts
@@ -23,3 +23,12 @@ export interface MatchResults {
     [key: string]: string
   };
 }
+
+export interface TransitionOptions {
+  tagName: string;
+  match: MatchResults;
+  location: Location;
+  isServer: boolean;
+  currentRoute: HTMLThRouteElement;
+  futureRoute: HTMLThRouteElement;
+}

--- a/packages/router/src/components/interfaces.ts
+++ b/packages/router/src/components/interfaces.ts
@@ -8,3 +8,18 @@ export interface RouteLinkClickEvent extends CustomEvent {
 export interface RouteLinkClickEventDetail {
   url: string;
 }
+
+export interface MatchOptions {
+  path?: string | string[];
+  exact?: boolean;
+  strict?: boolean;
+}
+
+export interface MatchResults {
+  path: string;
+  url: string;
+  isExact: boolean;
+  params: {
+    [key: string]: string
+  };
+}

--- a/packages/router/src/components/th-route.tsx
+++ b/packages/router/src/components/th-route.tsx
@@ -52,7 +52,6 @@ export function render(route: ThRoute) {
     const componentProps = {
       location: route.location,
       match,
-      isActive: route.isActive,
       isServer: route.isServer,
       ...match.params, // Spread the match params into the component properties.
     };

--- a/packages/router/src/components/th-route.tsx
+++ b/packages/router/src/components/th-route.tsx
@@ -1,4 +1,6 @@
 import { Component, Element, Method, Prop } from '@stencil/core';
+import { matchPath } from './utils';
+import { MatchResults } from './interfaces';
 
 @Component({
   tag: 'th-route',
@@ -9,12 +11,19 @@ export class ThRoute {
   @Element() element: HTMLElement;
   @Prop() url = '';
   @Prop() component = '';
-  @Prop({ context: 'isServer'}) isServer : boolean;
+  @Prop() exact = false;
+  @Prop({ context: 'isServer'}) isServer: boolean;
+  @Prop({ context: 'location' }) location: Location;
+
   private activeRoute = false;
 
   @Method()
-  isMatch(url: string) {
-    return url === this.url;
+  isMatch(pathname: string): MatchResults {
+    return matchPath(pathname, {
+      path: this.url,
+      exact: this.exact,
+      strict: true
+    });
   }
 
   @Method()
@@ -33,10 +42,21 @@ export class ThRoute {
 }
 
 export function render(route: ThRoute) {
-  
-  if (route.isMatch(location.pathname) && route.isServer) {
+  const match = route.isMatch(route.location.pathname);
+  if (match && route.isServer) {
     // if it's SSR or pre-render, just return the component
     route.setActive(true);
-    return <route.component></route.component>
+
+    // We can provide a component props attribute like stencil-router does, and pass that through here,
+    // and in the transitionView method in router.
+    const componentProps = {
+      location: route.location,
+      match,
+      isActive: route.isActive,
+      isServer: route.isServer,
+      ...match.params, // Spread the match params into the component properties.
+    };
+
+    return <route.component {...componentProps}></route.component>;
   }
 }

--- a/packages/router/src/components/utils/index.ts
+++ b/packages/router/src/components/utils/index.ts
@@ -1,0 +1,2 @@
+export { matchPath } from './match-path';
+export * from './transition';

--- a/packages/router/src/components/utils/match-path.ts
+++ b/packages/router/src/components/utils/match-path.ts
@@ -1,0 +1,67 @@
+import pathToRegexp, { Key } from './path-to-regex';
+import { MatchOptions, MatchResults } from '../interfaces';
+
+interface CompileOptions {
+  end: boolean;
+  strict: boolean;
+}
+
+const patternCache: {[key: string]: any } = {};
+const cacheLimit = 10000;
+let cacheCount = 0;
+
+// Memoized function for creating the path match regex
+function compilePath(pattern: string | string[], options: CompileOptions): { re: RegExp, keys: Key[]} {
+  const cacheKey = `${options.end}${options.strict}`;
+  const cache = patternCache[cacheKey] || (patternCache[cacheKey] = {});
+  const cachePattern = JSON.stringify(pattern);
+
+  if (cache[cachePattern]) {
+    return cache[cachePattern];
+  }
+
+  const keys: Key[] = [];
+  const re = pathToRegexp(pattern, keys, options);
+  const compiledPattern = { re, keys };
+
+  if (cacheCount < cacheLimit) {
+    cache[cachePattern] = compiledPattern;
+    cacheCount += 1;
+  }
+
+  return compiledPattern;
+}
+
+/**
+ * Public API for matching a URL pathname to a path pattern.
+ */
+export function matchPath(pathname: string, options: MatchOptions = {}): null | MatchResults {
+  if (typeof options === 'string') {
+    options = { path: options };
+  }
+
+  const { path = '/', exact = false, strict = false } = options;
+  const { re, keys } = compilePath(path, { end: exact, strict });
+  const match = re.exec(pathname);
+
+  if (!match) {
+    return null;
+  }
+
+  const [ url, ...values ] = match;
+  const isExact = pathname === url;
+
+  if (exact && !isExact) {
+    return null;
+  }
+
+  return <MatchResults>{
+    path, // the path pattern used to match
+    url: path === '/' && url === '' ? '/' : url, // the matched portion of the URL
+    isExact, // whether or not we matched exactly
+    params: keys.reduce((memo, key: Key, index) => {
+      memo[key.name] = values[index];
+      return memo;
+    }, {} as {[key: string]: string})
+  };
+}

--- a/packages/router/src/components/utils/path-to-regex.ts
+++ b/packages/router/src/components/utils/path-to-regex.ts
@@ -1,0 +1,356 @@
+/**
+ * TS adaption of https://github.com/pillarjs/path-to-regexp/blob/master/index.js
+ */
+
+export interface RegExpOptions {
+  sensitive?: boolean;
+  strict?: boolean;
+  end?: boolean;
+  delimiter?: string;
+  delimiters?: string | string[];
+  endsWith?: string | string[];
+}
+
+export interface ParseOptions {
+  delimiter?: string;
+  delimiters?: string | string[];
+}
+
+export interface Key {
+  name: string | number;
+  prefix: string;
+  delimiter: string;
+  optional: boolean;
+  repeat: boolean;
+  pattern: string;
+  partial: boolean;
+}
+
+export interface PathFunctionOptions {
+  encode?: (value: string) => string;
+}
+
+export type Token = string | Key;
+export type Path = string | RegExp | Array<string | RegExp>;
+export type PathFunction = (data?: { [key: string]: any }, options?: PathFunctionOptions) => string;
+
+/**
+ * Default configs.
+ */
+const DEFAULT_DELIMITER = '/';
+const DEFAULT_DELIMITERS = './';
+
+/**
+ * The main path matching regexp utility.
+ */
+const PATH_REGEXP = new RegExp([
+  // Match escaped characters that would otherwise appear in future matches.
+  // This allows the user to escape special characters that won't transform.
+  '(\\\\.)',
+  // Match Express-style parameters and un-named parameters with a prefix
+  // and optional suffixes. Matches appear as:
+  //
+  // "/:test(\\d+)?" => ["/", "test", "\d+", undefined, "?"]
+  // "/route(\\d+)"  => [undefined, undefined, undefined, "\d+", undefined]
+  '(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?'
+].join('|'), 'g');
+
+/**
+ * Parse a string for the raw tokens.
+ */
+export function parse(str: string, options?: ParseOptions): Token[] {
+  const tokens = [];
+  let key = 0;
+  let index = 0;
+  let path = '';
+  const defaultDelimiter = (options && options.delimiter) || DEFAULT_DELIMITER;
+  const delimiters = (options && options.delimiters) || DEFAULT_DELIMITERS;
+  let pathEscaped = false;
+  let res;
+
+  while ((res = PATH_REGEXP.exec(str)) !== null) {
+    const m = res[0];
+    const escaped = res[1];
+    const offset = res.index;
+    path += str.slice(index, offset);
+    index = offset + m.length;
+
+    // Ignore already escaped sequences.
+    if (escaped) {
+      path += escaped[1];
+      pathEscaped = true;
+      continue;
+    }
+
+    let prev = '';
+    const next = str[index];
+    const name = res[2];
+    const capture = res[3];
+    const group = res[4];
+    const modifier = res[5];
+
+    if (!pathEscaped && path.length) {
+      const k = path.length - 1;
+
+      if (delimiters.indexOf(path[k]) > -1) {
+        prev = path[k];
+        path = path.slice(0, k);
+      }
+    }
+
+    // Push the current path onto the tokens.
+    if (path) {
+      tokens.push(path);
+      path = '';
+      pathEscaped = false;
+    }
+
+    const partial = prev !== '' && next !== undefined && next !== prev;
+    const repeat = modifier === '+' || modifier === '*';
+    const optional = modifier === '?' || modifier === '*';
+    const delimiter = prev || defaultDelimiter;
+    const pattern = capture || group;
+
+    tokens.push({
+      name: name || key++,
+      prefix: prev,
+      delimiter: delimiter,
+      optional: optional,
+      repeat: repeat,
+      partial: partial,
+      pattern: pattern ? escapeGroup(pattern) : '[^' + escapeString(delimiter) + ']+?'
+    });
+  }
+
+  // Push any remaining characters.
+  if (path || index < str.length) {
+    tokens.push(path + str.substr(index));
+  }
+
+  return tokens;
+}
+
+/**
+ * Compile a string to a template function for the path.
+ */
+export function compile(str: string, options?: ParseOptions) {
+  return tokensToFunction(parse(str, options));
+}
+
+/**
+ * Expose a method for transforming tokens into the path function.
+ */
+export function tokensToFunction(tokens: Token[]): PathFunction {
+  // Compile all the tokens into regexps.
+  const matches = new Array(tokens.length);
+
+  // Compile all the patterns before compilation.
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (typeof token === 'object') {
+      matches[i] = new RegExp('^(?:' + token.pattern + ')$');
+    }
+  }
+
+  return function (data?: { [key: string]: any }, options?: PathFunctionOptions): string {
+    let path = '';
+    const encode = (options && options.encode) || encodeURIComponent;
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+
+      if (typeof token === 'string') {
+        path += token;
+        continue;
+      }
+
+      const value = data ? data[token.name] : undefined;
+      let segment;
+
+      if (Array.isArray(value)) {
+        if (!token.repeat) {
+          throw new TypeError('Expected "' + token.name + '" to not repeat, but got array');
+        }
+
+        if (value.length === 0) {
+          if (token.optional) continue;
+
+          throw new TypeError('Expected "' + token.name + '" to not be empty');
+        }
+
+        for (let j = 0; j < value.length; j++) {
+          segment = encode(value[j]);
+
+          if (!matches[i].test(segment)) {
+            throw new TypeError('Expected all "' + token.name + '" to match "' + token.pattern + '"');
+          }
+
+          path += (j === 0 ? token.prefix : token.delimiter) + segment;
+        }
+
+        continue;
+      }
+
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        segment = encode(String(value));
+
+        if (!matches[i].test(segment)) {
+          throw new TypeError('Expected "' + token.name + '" to match "' + token.pattern + '", but got "' + segment + '"');
+        }
+
+        path += token.prefix + segment;
+        continue;
+      }
+
+      if (token.optional) {
+        // Prepend partial segment prefixes.
+        if (token.partial) path += token.prefix;
+
+        continue;
+      }
+
+      throw new TypeError('Expected "' + token.name + '" to be ' + (token.repeat ? 'an array' : 'a string'));
+    }
+
+    return path;
+  };
+}
+
+/**
+ * Escape a regular expression string.
+ */
+function escapeString(str: string) {
+  return str.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
+}
+
+/**
+ * Escape the capturing group by escaping special characters and meaning.
+ */
+function escapeGroup(group: string) {
+  return group.replace(/([=!:$/()])/g, '\\$1');
+}
+
+/**
+ * Get the flags for a regexp from the options.
+ */
+function flags(options: RegExpOptions): string {
+  return options && options.sensitive ? '' : 'i';
+}
+
+/**
+ * Pull out keys from a regexp.
+ */
+function regexpToRegexp(path: RegExp, keys: Key[]): RegExp {
+  if (!keys) return path;
+
+  // Use a negative lookahead to match only capturing groups.
+  const groups = path.source.match(/\((?!\?)/g);
+
+  if (groups) {
+    for (let i = 0; i < groups.length; i++) {
+      keys.push({
+        name: i,
+        prefix: null,
+        delimiter: null,
+        optional: false,
+        repeat: false,
+        partial: false,
+        pattern: null
+      });
+    }
+  }
+
+  return path;
+}
+
+/**
+ * Transform an array into a regexp.
+ */
+function arrayToRegexp(path: Array<string | RegExp>, keys: Key[], options: RegExpOptions): RegExp {
+  const parts = [];
+
+  for (let i = 0; i < path.length; i++) {
+    parts.push(pathToRegexp(path[i], keys, options).source);
+  }
+
+  return new RegExp('(?:' + parts.join('|') + ')', flags(options));
+}
+
+/**
+ * Create a path regexp from string input.
+ */
+function stringToRegexp(path: string, keys: Key[], options: RegExpOptions): RegExp {
+  return tokensToRegExp(parse(path, options), keys, options);
+}
+
+/**
+ * Expose a function for taking tokens and returning a RegExp.
+ */
+export function tokensToRegExp(tokens: Token[], keys?: Key[], options?: RegExpOptions): RegExp {
+  options = options || {};
+
+  const strict = options.strict;
+  const end = options.end !== false;
+  const delimiter = escapeString(options.delimiter || DEFAULT_DELIMITER);
+  const delimiters = options.delimiters || DEFAULT_DELIMITERS;
+  const endsWith = [].concat(options.endsWith || []).map(escapeString).concat('$').join('|');
+  let route = '';
+  let isEndDelimited = false;
+
+  // Iterate over the tokens and create our regexp string.
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (typeof token === 'string') {
+      route += escapeString(token);
+      isEndDelimited = i === tokens.length - 1 && delimiters.indexOf(token[token.length - 1]) > -1;
+    } else {
+      const prefix = escapeString(token.prefix);
+      const capture = token.repeat
+        ? '(?:' + token.pattern + ')(?:' + prefix + '(?:' + token.pattern + '))*'
+        : token.pattern;
+
+      if (keys) keys.push(token);
+
+      if (token.optional) {
+        if (token.partial) {
+          route += prefix + '(' + capture + ')?';
+        } else {
+          route += '(?:' + prefix + '(' + capture + '))?';
+        }
+      } else {
+        route += prefix + '(' + capture + ')';
+      }
+    }
+  }
+
+  if (end) {
+    if (!strict) route += '(?:' + delimiter + ')?';
+
+    route += endsWith === '$' ? '$' : '(?=' + endsWith + ')';
+  } else {
+    if (!strict) route += '(?:' + delimiter + '(?=' + endsWith + '))?';
+    if (!isEndDelimited) route += '(?=' + delimiter + '|' + endsWith + ')';
+  }
+
+  return new RegExp('^' + route, flags(options));
+}
+
+/**
+ * Normalize the given path string, returning a regular expression.
+ *
+ * An empty array can be passed in for the keys, which will hold the
+ * placeholder key descriptions. For example, using `/user/:id`, `keys` will
+ * contain `[{ name: 'id', delimiter: '/', optional: false, repeat: false }]`.
+ */
+export default function pathToRegexp (path: Path, keys: Key[], options: RegExpOptions): RegExp {
+  if (path instanceof RegExp) {
+    return regexpToRegexp(path, keys);
+  }
+
+  if (Array.isArray(path)) {
+    return arrayToRegexp(path, keys, options);
+  }
+
+  return stringToRegexp(path, keys, options);
+}

--- a/packages/router/src/components/utils/transition.ts
+++ b/packages/router/src/components/utils/transition.ts
@@ -1,30 +1,36 @@
-import { MatchResults } from '../interfaces';
+import { TransitionOptions } from '../interfaces';
 
 export function trimUrl(url: string) {
   // this is super hacky but it works for now
   return url.endsWith('/') && url.length > 1 ? url.substring(0, url.length - 1) : url;
 }
 
-export function transitionViews(tagName: string, match: MatchResults, currentRoute: HTMLThRouteElement, futureRoute: HTMLThRouteElement) {
-  return addElementToDom(tagName, match, futureRoute).then((_newElement: HTMLElement) => {
-    return doTransition(currentRoute, futureRoute);
+export function transitionViews(options: TransitionOptions) {
+  return addElementToDom(options).then((_newElement: HTMLElement) => {
+    return doTransition(options.currentRoute, options.futureRoute);
   }).then(() => {
-    if (currentRoute) {
-      currentRoute.setActive(false);
+    if (options.currentRoute) {
+      options.currentRoute.setActive(false);
     }
-    futureRoute.setActive(true);
+    options.futureRoute.setActive(true);
   });
 }
 
-export function addElementToDom(tagName: string, match: MatchResults, futureRoute: HTMLThRouteElement) {
-  const element = document.createElement(tagName);
+export function addElementToDom(options: TransitionOptions) {
+  const element = document.createElement(options.tagName);
   element.classList.add(HIDE_HOST_ELEMENT);
-  element['match'] = match;
-  if (match) {
-    // Spread the match params into the component properties.
-    Object.keys(match.params).forEach((p) => element[p] = match.params[p]);
+  const componentProps = {
+    match: options.match,
+    location: options.location,
+    isServer: options.isServer,
+    ...options.match.params, // Spread the match params into the component properties.
+  };
+
+  if (options.match) {
+    // Spread the component properties into the component.
+    Object.keys(componentProps).forEach((p) => (element[p] = componentProps[p]));
   }
-  futureRoute.appendChild(element);
+  options.futureRoute.appendChild(element);
 
   const promise = (element as any).componentOnReady ? (element as any).componentOnReady() : Promise.resolve();
   return promise.then(() => {

--- a/packages/router/src/components/utils/transition.ts
+++ b/packages/router/src/components/utils/transition.ts
@@ -28,7 +28,7 @@ export function addElementToDom(options: TransitionOptions) {
 
   if (options.match) {
     // Spread the component properties into the component.
-    Object.keys(componentProps).forEach((p) => (element[p] = componentProps[p]));
+    Object.keys(componentProps).forEach((p) => ((<any>element)[p] = (<any>componentProps)[p]));
   }
   options.futureRoute.appendChild(element);
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,1 +1,3 @@
-export * from './components/index';
+export * from './components';
+export * from './components/interfaces';
+export * from './components/router-state';

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -1,2 +1,1 @@
-
-export * from './components';
+export * from './components/index';


### PR DESCRIPTION
The PR:

* Adds regex-based path matching to the routes, e.g. `/path/:param` - anything `path-to-regex` understands
* Makes appropriate changes to location handling based on server or client rendering
* Modifies the renderers to provide match data to the rendered component

Lots left we can do here but it should be fairly straightforward from here on.

@danbucholtz 